### PR TITLE
Add flexible contest problem search

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,7 @@
       margin-top: 1rem;
       flex-wrap: wrap;
     }
-    .lookup-form input,
-    .lookup-form select {
+    .lookup-form input {
       flex: 1;
       min-width: 150px;
       padding: 0.8rem;
@@ -171,12 +170,7 @@
       <div class="card lookup-card">
         <h2>🔍 Problem & Solution Finder</h2>
         <form class="lookup-form" onsubmit="handleSearch(event)">
-          <input type="text" id="lookup-query" placeholder="e.g. 2023 AMC 12B Problem 14" required>
-          <select id="lookup-subject">
-            <option value="amc12">AMC 12</option>
-            <option value="amc10">AMC 10</option>
-            <option value="aime">AIME</option>
-          </select>
+          <input type="text" id="lookup-query" placeholder="e.g. AIME I 2024 Problem 3" required>
           <button type="submit">Go</button>
         </form>
       </div>
@@ -207,19 +201,16 @@
   <footer>
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
   </footer>
+  <script src="search.js"></script>
   <script>
     function handleSearch(event) {
       event.preventDefault();
-      const q = document.getElementById('lookup-query').value.toUpperCase();
-      const subject = document.getElementById('lookup-subject').value;
-      const year = (q.match(/\b(19|20)\d{2}\b/) || [])[0];
-      const letter = (q.match(/AMC\s*1[02]\s*([AB])|1[02]\s*([AB])/) || []).slice(1).find(Boolean);
-      const problem = (q.match(/PROBLEM\s*(\d{1,2})|\b(\d{1,2})\b\s*PROBLEM|\bPROB\s*(\d{1,2})/) || []).slice(1).find(Boolean);
-      if (year && letter && problem) {
-        const url = `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_12${letter}_Problems/Problem_${problem}`;
-        window.open(url);
+      const q = document.getElementById('lookup-query').value;
+      const url = buildAoPSUrl(q);
+      if (url) {
+        window.open(url, '_blank');
       } else {
-        alert("Please enter 'YEAR AMC 12A/B Problem N'");
+        alert("Could not parse that contest query. Try '2024 AMC 12B Problem 3'.");
       }
     }
   </script>

--- a/search.js
+++ b/search.js
@@ -1,0 +1,73 @@
+function buildAoPSUrl(query) {
+  const tokens = (query || '').toUpperCase().match(/[A-Z0-9]+/g);
+  if (!tokens) return null;
+  let year, exam, level, variant, problem;
+
+  // first pass: identify year and exam with possible attached info
+  for (const t of tokens) {
+    if (!year && /^(19|20)\d{2}$/.test(t)) {
+      year = t;
+      continue;
+    }
+    if (!exam) {
+      if (t.startsWith('AMC')) {
+        exam = 'AMC';
+        const rest = t.slice(3);
+        const match = rest.match(/(10|12)([AB])?/);
+        if (match) {
+          level = match[1];
+          if (match[2]) variant = match[2];
+        }
+        continue;
+      }
+      if (t.startsWith('AIME')) {
+        exam = 'AIME';
+        const rest = t.slice(4);
+        const match = rest.match(/(II|I|2|1)/);
+        if (match) {
+          variant = match[1].replace('1', 'I').replace('2', 'II');
+        }
+        continue;
+      }
+    }
+  }
+
+  // second pass: pick up missing attributes and problem number
+  let afterProblem = false;
+  for (const t of tokens) {
+    if (t === 'PROBLEM') { afterProblem = true; continue; }
+    if (!exam && t === 'AIME') { exam = 'AIME'; continue; }
+    if (!exam && t === 'AMC') { exam = 'AMC'; continue; }
+    if (exam === 'AMC') {
+      const combined = t.match(/^(10|12)(A|B)$/);
+      if (!level && !variant && combined) { level = combined[1]; variant = combined[2]; continue; }
+      if (!level && (t === '10' || t === '12')) { level = t; continue; }
+      if (!variant && (t === 'A' || t === 'B')) { variant = t; continue; }
+    }
+    if (exam === 'AIME') {
+      if (!variant && (t === 'I' || t === 'II' || t === '1' || t === '2')) {
+        variant = t.replace('1', 'I').replace('2', 'II');
+        continue;
+      }
+    }
+    if (/^\d{1,2}$/.test(t)) {
+      if (t === year) continue;
+      if (exam === 'AMC' && t === level && !afterProblem) continue;
+      if (!problem) { problem = t; afterProblem = false; }
+    }
+  }
+
+  if (!year || !exam || !problem) return null;
+  if (exam === 'AMC') {
+    if (!level || !variant) return null;
+    return `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_${level}${variant}_Problems/Problem_${problem}`;
+  }
+  if (!variant) return null;
+  return `https://artofproblemsolving.com/wiki/index.php/${year}_AIME_${variant}_Problems/Problem_${problem}`;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { buildAoPSUrl };
+} else {
+  window.buildAoPSUrl = buildAoPSUrl;
+}

--- a/tests/math/search.test.js
+++ b/tests/math/search.test.js
@@ -1,0 +1,32 @@
+const { buildAoPSUrl } = require('../../search.js');
+
+const tests = [
+  {
+    q: '2024 AMC 12B Problem 4',
+    url: 'https://artofproblemsolving.com/wiki/index.php/2024_AMC_12B_Problems/Problem_4'
+  },
+  {
+    q: 'Problem 3 AIME I 2024',
+    url: 'https://artofproblemsolving.com/wiki/index.php/2024_AIME_I_Problems/Problem_3'
+  },
+  {
+    q: 'AIME 2 2019 #6',
+    url: 'https://artofproblemsolving.com/wiki/index.php/2019_AIME_II_Problems/Problem_6'
+  },
+  {
+    q: 'AMC10A 2022 problem 10',
+    url: 'https://artofproblemsolving.com/wiki/index.php/2022_AMC_10A_Problems/Problem_10'
+  }
+];
+
+let passed = 0;
+for (const t of tests) {
+  const got = buildAoPSUrl(t.q);
+  if (got === t.url) {
+    console.log('PASS', t.q);
+    passed++;
+  } else {
+    console.error('FAIL', t.q, '\n expected:', t.url, '\n got:', got);
+  }
+}
+console.log(`${passed}/${tests.length} tests passed`);


### PR DESCRIPTION
## Summary
- Allow contest problem queries for AMC and AIME in any word order, mapping to AoPS pages.
- Replace previous static form with a single search bar backed by robust parser.
- Add tests covering AMC and AIME search cases.

## Testing
- `node tests/math/search.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892a1ed5ccc8327b0946bbc98f58753