### PR TITLE
Revamp homepage layout and add feature pages

### DIFF
--- a/books.html
+++ b/books.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Books - OlympiadPrep</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html">Home</a>
+        <a href="timeline.html">Timeline</a>
+        <a href="tutor.html">Need a Tutor</a>
+        <a href="books.html" class="active">Books</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <h2>📚 Recommended Books</h2>
+    <ul class="book-list">
+      <li>Art of Problem Solving Volume 1</li>
+      <li>Art of Problem Solving Volume 2</li>
+      <li>Problem-Solving Strategies by Arthur Engel</li>
+      <li>102 Combinatorial Problems by Titu Andreescu & Zuming Feng</li>
+    </ul>
+  </main>
+  <footer>
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,208 +4,53 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OlympiadPrep - Home</title>
-  <style>
-    :root {
-      --bg: #f4f6f8;
-      --primary: #0059ff;
-      --primary-dark: #0047c3;
-      --accent: #00d084;
-      --text: #1e1e1e;
-      --muted: #6b6b6b;
-      --card-bg: #ffffff;
-      --shadow: rgba(0, 0, 0, 0.1);
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      font-family: 'Inter', sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-      line-height: 1.6;
-    }
-    header {
-      background: var(--primary);
-      color: white;
-      padding: 2.5rem 1rem;
-      text-align: center;
-      box-shadow: 0 2px 8px var(--shadow);
-    }
-    header h1 { font-size: 2.5rem; margin: 0; }
-    header p { margin-top: 0.5rem; color: rgba(255,255,255,0.85); }
-    nav {
-      background: var(--card-bg);
-      display: flex;
-      justify-content: center;
-      gap: 2rem;
-      padding: 1rem;
-      box-shadow: 0 1px 6px var(--shadow);
-      position: sticky;
-      top: 0;
-      z-index: 10;
-    }
-    nav a {
-      text-decoration: none;
-      color: var(--muted);
-      font-weight: 500;
-      position: relative;
-      padding: 0.5rem;
-    }
-    nav a:hover, nav a.active {
-      color: var(--primary);
-    }
-    main {
-      flex: 1;
-      display: grid;
-      grid-template-columns: 1fr 300px;
-      gap: 2rem;
-      max-width: 1200px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-    }
-    .content {
-      display: flex;
-      flex-direction: column;
-      gap: 2rem;
-    }
-    .card {
-      background: var(--card-bg);
-      border-radius: 12px;
-      padding: 1.5rem;
-      box-shadow: 0 4px 16px var(--shadow);
-      transition: transform 0.2s, box-shadow 0.2s;
-    }
-    .card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 8px 24px var(--shadow);
-    }
-    .lookup-card {
-      position: relative;
-      border-left: 4px solid var(--primary);
-    }
-    .lookup-card h2 {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 1.4rem;
-      margin-top: 0;
-    }
-    .lookup-form {
-      display: flex;
-      gap: 1rem;
-      margin-top: 1rem;
-      flex-wrap: wrap;
-    }
-    .lookup-form input,
-    .lookup-form select {
-      flex: 1;
-      min-width: 150px;
-      padding: 0.8rem;
-      border: 1px solid #ccc;
-      border-radius: 8px;
-      font-size: 1rem;
-    }
-    .lookup-form button {
-      background: var(--accent);
-      border: none;
-      color: white;
-      padding: 0.8rem 1.5rem;
-      border-radius: 8px;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-    .lookup-form button:hover {
-      background: #00b36a;
-    }
-    .sidebar {
-      display: flex;
-      flex-direction: column;
-      gap: 1.5rem;
-    }
-    .sidebar h3 {
-      margin: 0 0 0.5rem;
-      font-size: 1.2rem;
-      color: var(--primary);
-    }
-    .sidebar ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-    .sidebar li {
-      margin: 0.5rem 0;
-    }
-    .sidebar a {
-      color: var(--muted);
-      text-decoration: none;
-      transition: color 0.2s;
-    }
-    .sidebar a:hover {
-      color: var(--primary);
-    }
-    footer {
-      text-align: center;
-      padding: 1.5rem;
-      font-size: 0.9rem;
-      color: var(--muted);
-      background: var(--card-bg);
-    }
-    @media(max-width: 900px) {
-      main { grid-template-columns: 1fr; }
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header>
-    <h1>OlympiadPrep</h1>
-    <p>Precision Tools & Strategic Guides for Contest Success</p>
-  </header>
-  <nav>
-    <a href="#" class="active">Home</a>
-    <a href="#about">About</a>
-  </nav>
-  <main>
-    <div class="content">
-      <div class="card lookup-card">
-        <h2>🔍 Problem & Solution Finder</h2>
-        <form class="lookup-form" onsubmit="handleSearch(event)">
-          <input type="text" id="lookup-query" placeholder="e.g. 2023 AMC 12B Problem 14" required>
-          <select id="lookup-subject">
-            <option value="amc12">AMC 12</option>
-            <option value="amc10">AMC 10</option>
-            <option value="aime">AIME</option>
-          </select>
-          <button type="submit">Go</button>
-        </form>
-      </div>
-      <div class="card">
-        <h2>📘 Olympiad Study Prep</h2>
-        <p>Craft a tailored timeline, take diagnostics, and explore topic-based resources.</p>
-        <p><a href="studyguide.html" style="color: var(--accent); font-weight: 500;">Launch Study Guide →</a></p>
-      </div>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html" class="active">Home</a>
+        <a href="timeline.html">Timeline</a>
+        <a href="tutor.html">Need a Tutor</a>
+        <a href="books.html">Books</a>
+      </nav>
     </div>
-    <aside class="sidebar">
-      <div class="card">
-        <h3>Quick Links</h3>
-        <ul>
-          <li><a href="amc12.html">AMC 12 Archive</a></li>
-          <li><a href="amc10.html">AMC 10 Archive</a></li>
-          <li><a href="aime.html">AIME Archive</a></li>
-        </ul>
-      </div>
-      <div class="card">
-        <h3>Upcoming Tools</h3>
-        <ul>
-          <li><a href="#">AI Tutor (Beta)</a></li>
-          <li><a href="#">Video Walkthroughs</a></li>
-        </ul>
-      </div>
-    </aside>
+  </header>
+  <section class="hero">
+    <div class="container">
+      <h2>Your journey to math contest excellence</h2>
+      <form class="lookup-form" onsubmit="handleSearch(event)">
+        <input type="text" id="lookup-query" placeholder="e.g. 2023 AMC 12B Problem 14" required>
+        <select id="lookup-subject">
+          <option value="amc12">AMC 12</option>
+          <option value="amc10">AMC 10</option>
+          <option value="aime">AIME</option>
+        </select>
+        <button type="submit">Search</button>
+      </form>
+    </div>
+  </section>
+  <main class="features container">
+    <div class="card">
+      <h3>📅 Build a Timeline</h3>
+      <p>Plan your preparation with a clear schedule.</p>
+      <a href="timeline.html">Start Planning →</a>
+    </div>
+    <div class="card">
+      <h3>👩‍🏫 Need a Tutor?</h3>
+      <p>Connect with experienced mentors for one-on-one help.</p>
+      <a href="tutor.html">Find a Tutor →</a>
+    </div>
+    <div class="card">
+      <h3>📚 Recommended Books</h3>
+      <p>Explore curated reading to sharpen your skills.</p>
+      <a href="books.html">Browse Books →</a>
+    </div>
   </main>
   <footer>
-    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
   </footer>
   <script>
     function handleSearch(event) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,127 @@
+:root {
+  --bg: #f4f6f8;
+  --primary: #0059ff;
+  --accent: #00d084;
+  --text: #1e1e1e;
+  --muted: #6b6b6b;
+  --card-bg: #ffffff;
+  --shadow: rgba(0, 0, 0, 0.1);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+.site-header {
+  background: var(--card-bg);
+  box-shadow: 0 1px 6px var(--shadow);
+}
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+.logo {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--primary);
+}
+.site-nav a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: var(--muted);
+  font-weight: 500;
+}
+.site-nav a:hover, .site-nav a.active {
+  color: var(--primary);
+}
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: var(--primary);
+  color: white;
+}
+.hero h2 {
+  margin-top: 0;
+  font-weight: 400;
+}
+.lookup-form {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.lookup-form input,
+.lookup-form select {
+  padding: 0.8rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+.lookup-form button {
+  background: var(--accent);
+  border: none;
+  color: white;
+  padding: 0.8rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.lookup-form button:hover {
+  background: #00b36a;
+}
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  padding: 3rem 0;
+}
+.card {
+  background: var(--card-bg);
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px var(--shadow);
+  transition: transform 0.2s, box-shadow 0.2s;
+  text-align: center;
+}
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.card a {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: none;
+}
+main.container {
+  padding: 2rem 0;
+}
+.book-list {
+  list-style: disc;
+  margin-left: 1.5rem;
+}
+footer {
+  text-align: center;
+  padding: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin-top: auto;
+  background: var(--card-bg);
+}
+@media (max-width: 600px) {
+  .lookup-form { flex-direction: column; }
+  .site-nav a { margin-left: 0.5rem; }
+}

--- a/timeline.html
+++ b/timeline.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Timeline - OlympiadPrep</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html">Home</a>
+        <a href="timeline.html" class="active">Timeline</a>
+        <a href="tutor.html">Need a Tutor</a>
+        <a href="books.html">Books</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <h2>📅 Build Your Timeline</h2>
+    <p>Map out your preparation with milestones and deadlines. This page is under construction.</p>
+  </main>
+  <footer>
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+  </footer>
+</body>
+</html>

--- a/tutor.html
+++ b/tutor.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Need a Tutor - OlympiadPrep</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html">Home</a>
+        <a href="timeline.html">Timeline</a>
+        <a href="tutor.html" class="active">Need a Tutor</a>
+        <a href="books.html">Books</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <h2>👩‍🏫 Need a Tutor?</h2>
+    <p>Connect with experienced mentors for personalized guidance. This page is under construction.</p>
+  </main>
+  <footer>
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Redesign landing page with centered hero search bar and feature cards
- Add global stylesheet and navigation links to Timeline, Tutor, and Books pages
- Stub out placeholder pages for study timeline, tutoring, and book recommendations

## Testing
- `pytest` (no tests ran)
- `npm test` (fails: package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_6892a9ed954c8327afc0a4ff4c41ae2d