### PR TITLE
Add diagnostic flow and improve site styling

### DIFF
--- a/diagnostic.html
+++ b/diagnostic.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Diagnostic Test - OlympiadPrep</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html">Home</a>
+        <a href="timeline.html" class="active">Timeline</a>
+        <a href="tutor.html">Need a Tutor</a>
+        <a href="books.html">Books</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <h2>📝 Diagnostic Test</h2>
+    <p>This diagnostic assessment is under construction. Once ready, it will help tailor a study plan to your goals.</p>
+  </main>
+  <footer>
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,9 @@ body {
 .site-header {
   background: var(--primary);
   box-shadow: 0 1px 6px var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 .site-header .container {
   display: flex;
@@ -113,6 +116,43 @@ body {
 }
 main.container {
   padding: 2rem 0;
+}
+.card.diagnostic-card {
+  max-width: 500px;
+  margin: 1rem auto;
+  text-align: left;
+}
+.diagnostic-form {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.diagnostic-form select,
+.diagnostic-form button {
+  padding: 0.75rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+}
+.diagnostic-form button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  align-self: flex-start;
+}
+.diagnostic-form button:hover {
+  background: #1593b8;
 }
 .book-list {
   list-style: disc;

--- a/timeline.html
+++ b/timeline.html
@@ -20,7 +20,28 @@
   </header>
   <main class="container">
     <h2>📅 Build Your Timeline</h2>
-    <p>Map out your preparation with milestones and deadlines. This page is under construction.</p>
+    <div class="card diagnostic-card">
+      <p>Before we craft your personalized study schedule, you’ll need to take a quick diagnostic test.</p>
+      <form class="diagnostic-form" action="diagnostic.html" method="get">
+        <div class="form-group">
+          <label for="subject">Subject</label>
+          <select id="subject" name="subject">
+            <option value="math">Math</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="goal">Goal</label>
+          <select id="goal" name="goal" required>
+            <option value="" disabled selected>Select your goal</option>
+            <option value="amc">AMC</option>
+            <option value="aime">AIME</option>
+            <option value="usamo">USAMO</option>
+            <option value="usajmo">USAJMO</option>
+          </select>
+        </div>
+        <button type="submit">Start Diagnostic →</button>
+      </form>
+    </div>
   </main>
   <footer>
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.


### PR DESCRIPTION
## Summary
- Prompt users on the Timeline page to choose a subject and goal before starting a diagnostic test.
- Introduce a placeholder Diagnostic Test page for future content.
- Enhance overall site polish with a sticky header and styled diagnostic form.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892b7a868988327a5b503f99f6390e0