### PR TITLE
Display study plan after diagnostic test

### DIFF
--- a/diagnostic.html
+++ b/diagnostic.html
@@ -21,10 +21,12 @@
   <main class="container">
     <h2>📝 Diagnostic Test</h2>
     <div id="quiz"></div>
+    <div id="study-plan"></div>
   </main>
   <footer>
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
   </footer>
+  <script src="plan.js"></script>
   <script src="tests/math/diagnostic_data.js"></script>
   <script src="tests/math/diagnostic.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -157,48 +157,9 @@
     }
   </script>
 
-  <!-- ✅✅ NEW: Script to load plan.json -->
+  <script src="plan.js"></script>
   <script>
-    fetch('plan.json')
-      .then(response => {
-        if (!response.ok) {
-          throw new Error('No plan found.');
-        }
-        return response.json();
-      })
-      .then(data => {
-        const container = document.getElementById('study-plan');
-        if (!container) return;
-
-        const table = document.createElement('table');
-        table.border = "1";
-        table.style.borderCollapse = "collapse";
-        table.style.width = "100%";
-        table.style.marginTop = "1em";
-
-        // Header row
-        const header = table.insertRow();
-        header.innerHTML = "<th>Date</th><th>Tasks</th>";
-
-        for (const day of data.schedule) {
-          const row = table.insertRow();
-          const dateCell = row.insertCell();
-          dateCell.textContent = day.date;
-
-          const taskCell = row.insertCell();
-          taskCell.innerHTML = day.tasks.join("<br>");
-        }
-
-        container.innerHTML = ""; // Clear placeholder
-        container.appendChild(table);
-      })
-      .catch(error => {
-        const container = document.getElementById('study-plan');
-        if (container) {
-          container.textContent = "No study plan found. Please generate one.";
-        }
-        console.error(error);
-      });
+    loadStudyPlan('study-plan');
   </script>
 </body>
 </html>

--- a/plan.js
+++ b/plan.js
@@ -1,0 +1,51 @@
+function formatTask(task) {
+  if (typeof task === 'string') return task;
+  const parts = [];
+  if (task.type) parts.push(task.type);
+  if (task.resource) parts.push(task.resource);
+  if (task.topic) parts.push(`(${task.topic})`);
+  if (task.pages) parts.push(`pp. ${task.pages}`);
+  if (Array.isArray(task.problems)) parts.push(`problems ${task.problems.join(', ')}`);
+  if (typeof task.timed === 'boolean') parts.push(task.timed ? '[timed]' : '[untimed]');
+  return parts.join(' ');
+}
+
+function loadStudyPlan(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  fetch('plan.json')
+    .then(response => {
+      if (!response.ok) throw new Error('No plan found.');
+      return response.json();
+    })
+    .then(data => {
+      const plan = data.study_plan || data.schedule;
+      if (!plan) throw new Error('Invalid plan data.');
+
+      const table = document.createElement('table');
+      table.border = '1';
+      table.style.borderCollapse = 'collapse';
+      table.style.width = '100%';
+      table.style.marginTop = '1em';
+
+      const header = table.insertRow();
+      header.innerHTML = '<th>Date</th><th>Tasks</th>';
+
+      for (const day of plan) {
+        const row = table.insertRow();
+        const dateCell = row.insertCell();
+        dateCell.textContent = day.date;
+        const taskCell = row.insertCell();
+        const tasks = (day.tasks || []).map(formatTask);
+        taskCell.innerHTML = tasks.join('<br>');
+      }
+
+      container.innerHTML = '';
+      container.appendChild(table);
+    })
+    .catch(error => {
+      container.textContent = 'No study plan found. Please generate one.';
+      console.error(error);
+    });
+}

--- a/tests/math/diagnostic.js
+++ b/tests/math/diagnostic.js
@@ -103,6 +103,7 @@ function gradeTest(test, form) {
     reviewList.appendChild(li);
   });
   container.appendChild(reviewList);
+  loadStudyPlan('study-plan');
 }
 
 renderTest(diagnosticTests[level]);


### PR DESCRIPTION
## Summary
- Add reusable `plan.js` loader to render study schedules from `plan.json`.
- Integrate loader with home page and diagnostic workflow so the plan appears once a test is completed.
- Support complex task objects and both `study_plan` and `schedule` JSON structures.

## Testing
- `pytest`
- `python -m py_compile study_plan.py`


------
https://chatgpt.com/codex/tasks/task_e_68941c09291c8327a658fc9c93c63bbe