### PR TITLE
Show timeline after diagnostic on dedicated page

### DIFF
--- a/diagnostic.html
+++ b/diagnostic.html
@@ -12,7 +12,7 @@
       <h1 class="logo">OlympiadPrep</h1>
       <nav class="site-nav">
         <a href="index.html">Home</a>
-        <a href="timeline.html" class="active">Timeline</a>
+        <a href="timeline.html">Timeline</a>
         <a href="tutor.html">Need a Tutor</a>
         <a href="books.html">Books</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <div class="card">
       <h3>📅 Build a Timeline</h3>
       <p>Plan your preparation with a clear schedule.</p>
-      <a href="timeline.html">Start Planning →</a>
+      <a href="planning.html">Start Planning →</a>
     </div>
     <div class="card">
       <h3>👩‍🏫 Need a Tutor?</h3>

--- a/plan.js
+++ b/plan.js
@@ -22,12 +22,10 @@ function loadStudyPlan(containerId) {
     .then(data => {
       const plan = data.study_plan || data.schedule;
       if (!plan) throw new Error('Invalid plan data.');
+      window.loadedPlan = plan;
 
       const table = document.createElement('table');
-      table.border = '1';
-      table.style.borderCollapse = 'collapse';
-      table.style.width = '100%';
-      table.style.marginTop = '1em';
+      table.className = 'plan-table';
 
       const header = table.insertRow();
       header.innerHTML = '<th>Date</th><th>Tasks</th>';

--- a/planning.html
+++ b/planning.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Build Timeline - OlympiadPrep</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="logo">OlympiadPrep</h1>
+      <nav class="site-nav">
+        <a href="index.html">Home</a>
+        <a href="timeline.html">Timeline</a>
+        <a href="tutor.html">Need a Tutor</a>
+        <a href="books.html">Books</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    <h2>📅 Build Your Timeline</h2>
+    <div class="card diagnostic-card">
+      <p>Before we craft your personalized study schedule, you’ll need to take a quick diagnostic test.</p>
+      <form class="diagnostic-form" action="diagnostic.html" method="get">
+        <div class="form-group">
+          <label for="subject">Subject</label>
+          <select id="subject" name="subject">
+            <option value="math">Math</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="goal">Goal</label>
+          <select id="goal" name="goal" required>
+            <option value="" disabled selected>Select your goal</option>
+            <option value="amc10">AMC 10</option>
+            <option value="amc12">AMC 12</option>
+            <option value="aime">AIME</option>
+            <option value="usamo">USAMO</option>
+            <option value="usajmo">USAJMO</option>
+          </select>
+        </div>
+        <button type="submit">Start Diagnostic →</button>
+      </form>
+    </div>
+  </main>
+  <footer>
+    © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,46 @@ footer {
   margin-top: auto;
   background: var(--card-bg);
 }
+
+/* Timeline table styling */
+.plan-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  box-shadow: 0 2px 8px var(--shadow);
+  background: var(--card-bg);
+}
+.plan-table th,
+.plan-table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid #e5e7eb;
+  text-align: left;
+}
+.plan-table th {
+  background: var(--primary);
+  color: #fff;
+}
+.plan-table tr:nth-child(even) td {
+  background: #f1f5f9;
+}
+
+.calendar-export {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+.calendar-export button {
+  padding: 0.75rem 1.25rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+}
+.calendar-export button:hover {
+  background: #1593b8;
+}
 @media (max-width: 600px) {
   .lookup-form { flex-direction: column; }
   .site-nav a { margin-left: 0.5rem; }

--- a/tests/math/diagnostic.js
+++ b/tests/math/diagnostic.js
@@ -103,7 +103,13 @@ function gradeTest(test, form) {
     reviewList.appendChild(li);
   });
   container.appendChild(reviewList);
-  loadStudyPlan('study-plan');
+  const summary = { correct, total: test.length, strengths, weaknesses };
+  try {
+    localStorage.setItem('lastTestResults', JSON.stringify(summary));
+  } catch (e) {
+    console.error('Failed to save summary', e);
+  }
+  window.location.href = 'timeline.html';
 }
 
 renderTest(diagnosticTests[level]);

--- a/timeline.html
+++ b/timeline.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Timeline - OlympiadPrep</title>
+  <title>Your Timeline - OlympiadPrep</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -19,33 +19,21 @@
     </div>
   </header>
   <main class="container">
-    <h2>📅 Build Your Timeline</h2>
-    <div class="card diagnostic-card">
-      <p>Before we craft your personalized study schedule, you’ll need to take a quick diagnostic test.</p>
-      <form class="diagnostic-form" action="diagnostic.html" method="get">
-        <div class="form-group">
-          <label for="subject">Subject</label>
-          <select id="subject" name="subject">
-            <option value="math">Math</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="goal">Goal</label>
-          <select id="goal" name="goal" required>
-            <option value="" disabled selected>Select your goal</option>
-            <option value="amc10">AMC 10</option>
-            <option value="amc12">AMC 12</option>
-            <option value="aime">AIME</option>
-            <option value="usamo">USAMO</option>
-            <option value="usajmo">USAJMO</option>
-          </select>
-        </div>
-        <button type="submit">Start Diagnostic →</button>
-      </form>
+    <h2>📅 Your Study Timeline</h2>
+    <div id="summary"></div>
+    <div id="study-plan">Loading timeline...</div>
+    <div class="calendar-export">
+      <button id="download-ics">Download iCal</button>
+      <button id="google-calendar">Add to Google Calendar</button>
     </div>
   </main>
   <footer>
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
   </footer>
+  <script src="plan.js"></script>
+  <script src="timeline.js"></script>
+  <script>
+    loadStudyPlan('study-plan');
+  </script>
 </body>
 </html>

--- a/timeline.js
+++ b/timeline.js
@@ -1,0 +1,67 @@
+function displaySummary() {
+  const raw = localStorage.getItem('lastTestResults');
+  if (!raw) return;
+  try {
+    const { correct, total, strengths = [], weaknesses = [] } = JSON.parse(raw);
+    const div = document.getElementById('summary');
+    let html = `<p>You scored ${correct} out of ${total}.</p>`;
+    if (strengths.length) {
+      html += `<p>Strengths: ${strengths.join(', ')}</p>`;
+    }
+    if (weaknesses.length) {
+      html += `<p>Topics to review: ${weaknesses.join(', ')}</p>`;
+    }
+    div.innerHTML = html;
+    localStorage.removeItem('lastTestResults');
+  } catch (e) {
+    console.error('Unable to load summary', e);
+  }
+}
+
+function generateICS(plan) {
+  if (!Array.isArray(plan)) return '';
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//OlympiadPrep//StudyPlan//EN'
+  ];
+  plan.forEach((day, idx) => {
+    const date = day.date.replace(/-/g, '');
+    const tasks = (day.tasks || []).map(formatTask).join(' \n');
+    lines.push('BEGIN:VEVENT');
+    lines.push(`UID:${date}-${idx}@olympiadprep`);
+    lines.push(`DTSTAMP:${date}T000000Z`);
+    lines.push(`DTSTART;VALUE=DATE:${date}`);
+    lines.push(`DTEND;VALUE=DATE:${date}`);
+    lines.push('SUMMARY:Study Plan');
+    lines.push(`DESCRIPTION:${tasks}`);
+    lines.push('END:VEVENT');
+  });
+  lines.push('END:VCALENDAR');
+  return lines.join('\r\n');
+}
+
+function setupExport() {
+  const dl = document.getElementById('download-ics');
+  const gcal = document.getElementById('google-calendar');
+  dl.addEventListener('click', () => {
+    const ics = generateICS(window.loadedPlan);
+    const blob = new Blob([ics], { type: 'text/calendar' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'study_plan.ics';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+  gcal.addEventListener('click', () => {
+    const ics = generateICS(window.loadedPlan);
+    const url = 'https://calendar.google.com/calendar/r?cid=' + encodeURIComponent('data:text/calendar;charset=utf8,' + ics);
+    window.open(url, '_blank');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  displaySummary();
+  setupExport();
+});


### PR DESCRIPTION
## Summary
- Introduced a dedicated timeline page that displays the generated study schedule and summary once the diagnostic test is completed.
- Added calendar export options (ICS download and Google Calendar) and polished table styling for a calendar-like look.
- Persisted diagnostic results in local storage, redirecting users to the timeline page after test completion.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68941f7827c083278959a77867bac364