### PR TITLE
Revamp homepage and timeline

### DIFF
--- a/books.html
+++ b/books.html
@@ -21,10 +21,10 @@
   <main class="container">
     <h2>📚 Recommended Books</h2>
     <ul class="book-list">
-      <li>Art of Problem Solving Volume 1</li>
-      <li>Art of Problem Solving Volume 2</li>
-      <li>Problem-Solving Strategies by Arthur Engel</li>
-      <li>102 Combinatorial Problems by Titu Andreescu & Zuming Feng</li>
+      <li><a href="https://artofproblemsolving.com/store/item/aops-vol1" target="_blank">Art of Problem Solving Volume 1</a></li>
+      <li><a href="https://artofproblemsolving.com/store/item/aops-vol2" target="_blank">Art of Problem Solving Volume 2</a></li>
+      <li><a href="https://www.amazon.com/Problem-Solving-Strategies-Arthur-Engel/dp/0387982191" target="_blank">Problem-Solving Strategies by Arthur Engel</a></li>
+      <li><a href="https://www.amazon.com/102-Combinatorial-Problems-Andreescu-Feng/dp/0817643346" target="_blank">102 Combinatorial Problems by Titu Andreescu & Zuming Feng</a></li>
     </ul>
   </main>
   <footer>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
   <section class="hero">
     <div class="container">
       <h2>Find any contest problem instantly</h2>
+      <p class="subtitle">Your AI-powered companion for Olympiad success.</p>
       <form class="lookup-form" onsubmit="handleSearch(event)">
         <input type="text" id="lookup-query" placeholder="e.g. AMC 12B 2023 Problem 14" required>
         <button type="submit">Search</button>
@@ -43,12 +44,6 @@
       <h3>📚 Recommended Books</h3>
       <p>Explore curated reading to sharpen your skills.</p>
       <a href="books.html">Browse Books →</a>
-    </div>
-
-    <!-- ✅✅ NEW: Study Plan Section -->
-    <div class="card" style="width: 100%;">
-      <h3>📝 Your Study Plan</h3>
-      <div id="study-plan">Loading study plan...</div>
     </div>
   </main>
 
@@ -157,9 +152,6 @@
     }
   </script>
 
-  <script src="plan.js"></script>
-  <script>
-    loadStudyPlan('study-plan');
-  </script>
+  
 </body>
 </html>

--- a/plan.js
+++ b/plan.js
@@ -10,7 +10,7 @@ function formatTask(task) {
   return parts.join(' ');
 }
 
-function loadStudyPlan(containerId) {
+function loadStudyPlan(containerId, perPage = 7) {
   const container = document.getElementById(containerId);
   if (!container) return;
 
@@ -24,23 +24,47 @@ function loadStudyPlan(containerId) {
       if (!plan) throw new Error('Invalid plan data.');
       window.loadedPlan = plan;
 
-      const table = document.createElement('table');
-      table.className = 'plan-table';
+      let currentPage = 0;
+      const totalPages = Math.ceil(plan.length / perPage);
 
-      const header = table.insertRow();
-      header.innerHTML = '<th>Date</th><th>Tasks</th>';
+      function render() {
+        container.innerHTML = '';
+        const table = document.createElement('table');
+        table.className = 'plan-table';
+        const header = table.insertRow();
+        header.innerHTML = '<th>Date</th><th>Tasks</th>';
+        const start = currentPage * perPage;
+        const end = Math.min(start + perPage, plan.length);
+        for (let i = start; i < end; i++) {
+          const day = plan[i];
+          const row = table.insertRow();
+          const dateCell = row.insertCell();
+          dateCell.textContent = day.date;
+          const taskCell = row.insertCell();
+          const tasks = (day.tasks || []).map(formatTask);
+          taskCell.innerHTML = tasks.join('<br>');
+        }
+        container.appendChild(table);
 
-      for (const day of plan) {
-        const row = table.insertRow();
-        const dateCell = row.insertCell();
-        dateCell.textContent = day.date;
-        const taskCell = row.insertCell();
-        const tasks = (day.tasks || []).map(formatTask);
-        taskCell.innerHTML = tasks.join('<br>');
+        if (totalPages > 1) {
+          const nav = document.createElement('div');
+          nav.className = 'pagination';
+          const prev = document.createElement('button');
+          prev.textContent = 'Prev';
+          prev.disabled = currentPage === 0;
+          prev.addEventListener('click', () => { currentPage--; render(); });
+          const info = document.createElement('span');
+          info.textContent = `Page ${currentPage + 1} of ${totalPages}`;
+          const next = document.createElement('button');
+          next.textContent = 'Next';
+          next.disabled = currentPage >= totalPages - 1;
+          next.addEventListener('click', () => { currentPage++; render(); });
+          nav.append(prev, info, next);
+          container.appendChild(nav);
+        }
       }
 
-      container.innerHTML = '';
-      container.appendChild(table);
+      render();
     })
     .catch(error => {
       container.textContent = 'No study plan found. Please generate one.';

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
 
 :root {
-  --bg: #f8fafc;
-  --primary: #0f4d92;
-  --accent: #1dacd6;
+  --bg: #f5f7fa;
+  --primary: #2563eb;
+  --accent: #6366f1;
   --text: #1e1e1e;
   --muted: #6b6b6b;
   --card-bg: #ffffff;
@@ -26,7 +26,7 @@ body {
   padding: 0 1rem;
 }
 .site-header {
-  background: var(--primary);
+  background: linear-gradient(90deg, var(--primary), var(--accent));
   box-shadow: 0 1px 6px var(--shadow);
   position: sticky;
   top: 0;
@@ -57,9 +57,14 @@ body {
 }
 .hero {
   text-align: center;
-  padding: 5rem 1rem;
-  background: linear-gradient(135deg, var(--primary), #142d6e);
+  padding: 6rem 1rem;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
   color: white;
+}
+.hero .subtitle {
+  margin-top: 0.5rem;
+  font-size: 1.25rem;
+  opacity: 0.9;
 }
 .hero h2 {
   margin-top: 0;
@@ -89,7 +94,7 @@ body {
   transition: background 0.2s;
 }
 .lookup-form button:hover {
-  background: #1593b8;
+  background: #4f46e5;
 }
 .features {
   display: grid;
@@ -152,7 +157,7 @@ main.container {
   align-self: flex-start;
 }
 .diagnostic-form button:hover {
-  background: #1593b8;
+  background: #4f46e5;
 }
 .book-list {
   list-style: disc;
@@ -179,11 +184,15 @@ footer {
 .plan-table td {
   padding: 0.75rem 1rem;
   border: 1px solid #e5e7eb;
-  text-align: left;
 }
 .plan-table th {
   background: var(--primary);
   color: #fff;
+  text-align: center;
+}
+.plan-table td {
+  text-align: left;
+  vertical-align: top;
 }
 .plan-table tr:nth-child(even) td {
   background: #f1f5f9;
@@ -204,7 +213,27 @@ footer {
   font-size: 1rem;
 }
 .calendar-export button:hover {
-  background: #1593b8;
+  background: #4f46e5;
+}
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+.pagination button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+}
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 @media (max-width: 600px) {
   .lookup-form { flex-direction: column; }

--- a/timeline.js
+++ b/timeline.js
@@ -56,7 +56,8 @@ function setupExport() {
   });
   gcal.addEventListener('click', () => {
     const ics = generateICS(window.loadedPlan);
-    const url = 'https://calendar.google.com/calendar/r?cid=' + encodeURIComponent('data:text/calendar;charset=utf8,' + ics);
+    const encoded = encodeURIComponent(ics);
+    const url = 'https://calendar.google.com/calendar/r?cid=' + encodeURIComponent('data:text/calendar;charset=utf8,' + encoded);
     window.open(url, '_blank');
   });
 }


### PR DESCRIPTION
## Summary
- Modernize homepage with startup styling, new tagline, and removal of embedded timeline
- Add book hyperlinks and paginate study plan for calendar-like weekly view
- Encode ICS data correctly for Google Calendar export

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689422bf14ac8327a30950ff83d578ab