### PR TITLE
Restore basic search bar behavior

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -47,14 +47,12 @@ document.addEventListener('DOMContentLoaded',()=>{
   const searchForm=document.getElementById('search-form');
   if(searchForm){
     searchForm.addEventListener('submit',e=>{
-      e.preventDefault();
       const q=searchForm.querySelector('input[name="q"]').value.trim();
-      if(!q) return;
+      if(!q){e.preventDefault();return;}
       if(q.toLowerCase().startsWith('aops:')){
+        e.preventDefault();
         const query=encodeURIComponent(q.slice(5).trim());
         location.href=`https://www.google.com/search?q=site:artofproblemsolving.com+${query}`;
-      }else{
-        location.href=`search.html?q=${encodeURIComponent(q)}`;
       }
     });
   }

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ footer{background:var(--color-muted);text-align:center;padding:1rem;}
   <section class="hero">
     <h1>Olympiad Prep Made Easy</h1>
     <p>Plan your journey through AMC, AIME, and beyond.</p>
-    <form id="search-form" role="search" aria-label="Site search">
+    <form id="search-form" role="search" aria-label="Site search" action="search.html">
       <label for="search-input" class="visually-hidden">Search</label>
       <input id="search-input" name="q" type="search" placeholder="Search resources" autocomplete="off">
     </form>

--- a/search.html
+++ b/search.html
@@ -58,7 +58,7 @@ footer{background:var(--color-muted);text-align:center;padding:1rem;}
 </header>
 <main id="main">
   <h1>Search Results</h1>
-  <form id="search-form" role="search" aria-label="Site search">
+  <form id="search-form" role="search" aria-label="Site search" action="search.html">
     <label for="search-input" class="visually-hidden">Search</label>
     <input id="search-input" name="q" type="search" placeholder="Search resources" autocomplete="off">
   </form>


### PR DESCRIPTION
## Summary
- Add explicit form action so search submissions work even without JavaScript
- Simplify JS handler to only hijack AoPS queries, letting normal searches use the form action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc63648f08327a0a628c834a74ec5