### PR TITLE
feat: add study plan engine CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 out/
 package-lock.json
+!engine/package-lock.json

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+out

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,25 @@
+# Engine
+
+Minimal TypeScript CLI that writes a study plan.
+
+## Commands
+
+Install dependencies:
+
+```bash
+npm i typescript@5 --save-dev
+```
+
+Build the project:
+
+```bash
+npm run build
+```
+
+Generate the plan:
+
+```bash
+npm run plan
+```
+
+Results are written to the `out/` directory as `plan.json`, `plan.md`, and `study.ics`.

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "engine",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "engine",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/engine/package.json
+++ b/engine/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "engine",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p .",
+    "plan": "node dist/cli.js --out out",
+    "typecheck": "tsc -p . --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/engine/src/cli.ts
+++ b/engine/src/cli.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildPlan } from './plan';
+import { exportJson, exportMarkdown, exportICS } from './exporters';
+
+function parseOutDir(): string {
+  const flag = '--out';
+  const idx = process.argv.indexOf(flag);
+  if (idx >= 0 && process.argv[idx + 1]) {
+    return process.argv[idx + 1];
+  }
+  return 'out';
+}
+
+function main() {
+  const outDir = parseOutDir();
+  fs.mkdirSync(outDir, { recursive: true });
+  const tasks = buildPlan();
+  exportJson(tasks, path.join(outDir, 'plan.json'));
+  exportMarkdown(tasks, path.join(outDir, 'plan.md'));
+  exportICS(tasks, path.join(outDir, 'study.ics'));
+}
+
+main();

--- a/engine/src/exporters.ts
+++ b/engine/src/exporters.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs';
+import { PlanTask } from './types';
+
+export function exportJson(tasks: PlanTask[], filePath: string): void {
+  const data = { tasks };
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+export function exportMarkdown(tasks: PlanTask[], filePath: string): void {
+  let lines = ['# Study Plan', ''];
+  for (const task of tasks) {
+    lines.push(`- ${task.date}: ${task.title}`);
+  }
+  fs.writeFileSync(filePath, lines.join('\n'));
+}
+
+export function exportICS(tasks: PlanTask[], filePath: string): void {
+  const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+  let lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//engine//EN'];
+  tasks.forEach((task, idx) => {
+    const date = task.date.replace(/-/g, '');
+    lines.push('BEGIN:VEVENT');
+    lines.push(`UID:${idx}@engine`);
+    lines.push(`DTSTAMP:${now}`);
+    lines.push(`DTSTART;VALUE=DATE:${date}`);
+    lines.push(`SUMMARY:${task.title}`);
+    lines.push('END:VEVENT');
+  });
+  lines.push('END:VCALENDAR');
+  fs.writeFileSync(filePath, lines.join('\n'));
+}

--- a/engine/src/plan.ts
+++ b/engine/src/plan.ts
@@ -1,0 +1,12 @@
+import { PlanTask } from './types';
+
+export function buildPlan(): PlanTask[] {
+  const today = new Date();
+  const tasks: PlanTask[] = [];
+  for (let i = 1; i <= 3; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() + i);
+    tasks.push({ title: `Task ${i}`, date: d.toISOString().slice(0, 10) });
+  }
+  return tasks;
+}

--- a/engine/src/types.ts
+++ b/engine/src/types.ts
@@ -1,0 +1,8 @@
+export interface PlanTask {
+  title: string;
+  date: string; // ISO date
+}
+
+export interface PlanJson {
+  tasks: PlanTask[];
+}

--- a/engine/tsconfig.json
+++ b/engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "ES2019"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add minimal TypeScript project under `engine/`
- build and run CLI exporting a 3-task plan to JSON, Markdown, and ICS
- include `engine/package-lock.json` and unignore it so `npm ci` succeeds

## Testing
- `npm ci`
- `npm run build`
- `npm run typecheck`
- `npm run plan`
- `ls out`

------
https://chatgpt.com/codex/tasks/task_e_689bc8113de083279ae360c305bf9e09