### PR TITLE
Add study plan page and redirect after diagnostic

### DIFF
--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -22,6 +22,12 @@
     "url": "diagnostic.html",
     "tags": ["diagnostic","quiz"],
     "summary": "Assess your skills to build a study plan."
+  },
+  {
+    "title": "Your Study Plan",
+    "url": "study-plan.html",
+    "tags": ["plan","schedule"],
+    "summary": "View the personalized study plan from your diagnostic."
   }
 ]
 

--- a/assets/site.js
+++ b/assets/site.js
@@ -257,6 +257,8 @@ document.addEventListener('DOMContentLoaded',()=>{
           download('plan.json',JSON.stringify(plan.plan,null,2));
           download('plan.md',plan.markdown);
           download('study.ics',plan.ics);
+          try{localStorage.setItem('studyPlan',plan.markdown);}catch(e){}
+          location.href='study-plan.html';
         }catch(err){
           console.error(err);
           planPre.textContent='Could not generate plan.';
@@ -266,6 +268,13 @@ document.addEventListener('DOMContentLoaded',()=>{
         planPre.textContent='Engine not loaded. Diagnostic results downloaded.';
       }
     });
+  }
+
+  // study plan page
+  const planDisplay=document.getElementById('plan-display');
+  if(planDisplay){
+    const md=localStorage.getItem('studyPlan');
+    planDisplay.textContent=md||'No plan found. Please take the diagnostic first.';
   }
 
   function download(name,content){

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,5 @@
   <url><loc>https://thjjjjjjjjjhhy.github.io/olympiad/tutor.html</loc></url>
   <url><loc>https://thjjjjjjjjjhhy.github.io/olympiad/search.html</loc></url>
   <url><loc>https://thjjjjjjjjjhhy.github.io/olympiad/diagnostic.html</loc></url>
+  <url><loc>https://thjjjjjjjjjhhy.github.io/olympiad/study-plan.html</loc></url>
 </urlset>

--- a/study-plan.html
+++ b/study-plan.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Your Study Plan - Olympiad Prep</title>
+<meta name="description" content="Personalized study plan generated from your diagnostic results.">
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="manifest.webmanifest">
+<meta property="og:title" content="Your Study Plan - Olympiad Prep">
+<meta property="og:description" content="Personalized study plan generated from your diagnostic results.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://thjjjjjjjjjhhy.github.io/olympiad/study-plan.html">
+<meta property="og:image" content="favicon.svg">
+<meta name="twitter:card" content="summary">
+<style>
+:root{--color-bg:#fff;--color-text:#111;--color-accent:#0b79d0;--color-accent-hover:#095a9e;--color-muted:#f4f4f4;--transition:0.2s ease-in-out;}
+[data-theme="dark"]{--color-bg:#121212;--color-text:#eaeaea;--color-accent:#4dabf7;--color-accent-hover:#339af0;--color-muted:#1f1f1f;}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{font-family:system-ui,sans-serif;background:var(--color-bg);color:var(--color-text);line-height:1.5;min-height:100vh;display:flex;flex-direction:column;}
+a{color:var(--color-accent);}a:hover,a:focus{color:var(--color-accent-hover);}
+.skip-link{position:absolute;left:-999px;top:0;background:var(--color-accent);color:#fff;padding:0.5rem;z-index:100;}
+.skip-link:focus{left:0;}
+header{background:var(--color-bg);box-shadow:0 2px 4px rgba(0,0,0,0.1);position:sticky;top:0;z-index:10;}
+header .inner{max-width:60rem;margin:0 auto;padding:0.5rem 1rem;display:flex;align-items:center;justify-content:space-between;}
+.logo{text-decoration:none;font-weight:bold;color:var(--color-text);}
+.menu-toggle{background:none;border:1px solid var(--color-text);padding:0.5rem;border-radius:0.25rem;}
+nav{position:fixed;top:0;right:0;bottom:0;width:70%;max-width:20rem;background:var(--color-bg);transform:translateX(100%);transition:transform var(--transition);padding:1rem;box-shadow:-2px 0 4px rgba(0,0,0,0.2);}
+nav.open{transform:translateX(0);}
+nav ul{list-style:none;display:flex;flex-direction:column;gap:1rem;}
+nav a{text-decoration:none;color:var(--color-text);}
+@media (min-width:700px){.menu-toggle{display:none;}nav{position:static;transform:none;box-shadow:none;width:auto;max-width:none;}nav ul{flex-direction:row;align-items:center;}}
+main{flex:1;max-width:60rem;margin:0 auto;padding:1rem;}
+pre{white-space:pre-wrap;background:var(--color-muted);padding:1rem;border-radius:0.5rem;}
+footer{background:var(--color-muted);text-align:center;padding:1rem;}
+:focus-visible{outline:2px solid var(--color-accent);outline-offset:2px;}
+@media (prefers-reduced-motion: reduce){*{transition:none!important;}}
+</style>
+<link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<header>
+  <div class="inner">
+    <a href="index.html" class="logo">Olympiad Prep</a>
+    <button id="menu-button" class="menu-toggle" aria-controls="site-nav" aria-expanded="false">Menu</button>
+    <nav id="site-nav">
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="planning.html">Timeline</a></li>
+        <li><a href="books.html">Books</a></li>
+        <li><a href="tutor.html">Tutor</a></li>
+        <li><button id="theme-toggle">Toggle theme</button></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+<main id="main">
+  <h1>Your Study Plan</h1>
+  <pre id="plan-display">Loading...</pre>
+</main>
+<footer>
+  <p>&copy; 2024 Olympiad Prep</p>
+</footer>
+<script type="module" src="assets/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link the timeline button to the diagnostic quiz and redirect users to a new study plan page after completion.
- Store the generated plan in local storage and load it on the study plan page.
- Include the new page in the search index and sitemap.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdbb608e88327b5a57300aa325c48