### PR TITLE
Fix exam problem search redirects

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -1,4 +1,5 @@
-document.addEventListener('DOMContentLoaded',()=>{
+if(typeof document!=='undefined'){
+  document.addEventListener('DOMContentLoaded',()=>{
   const root=document.documentElement;
   const themeBtn=document.getElementById('theme-toggle');
   const storedTheme=localStorage.getItem('theme');
@@ -46,9 +47,66 @@ document.addEventListener('DOMContentLoaded',()=>{
   // search form submit
   const searchForm=document.getElementById('search-form');
   if(searchForm){
+    function problemRedirect(q){
+      const ql=q.toLowerCase();
+      const tokens=(ql.match(/\w+/g)||[]);
+      let year,problem,exam='',grade;
+
+      const ym=ql.match(/(19|20)\d{2}/);
+      if(ym) year=ym[0];
+
+      if(/aime/.test(ql)){
+        const m=ql.match(/aime\s*(i{1,3}|1|2)?/);
+        if(m){
+          const v=m[1];
+          if(!v) exam='AIME';
+          else if(v==='i'||v==='1') exam='AIME_I';
+          else if(v==='ii'||v==='2') exam='AIME_II';
+          else exam=`AIME_${v.toUpperCase()}`;
+        }else exam='AIME';
+      }else if(/amc/.test(ql)){
+        const m=ql.match(/amc\s*(8|10|12)\s*([ab])?/);
+        if(m){
+          grade=m[1];
+          const letter=m[2]?m[2].toUpperCase():'';
+          exam=`AMC_${grade}${letter}`;
+        }else{
+          const combo=ql.match(/amc(8|10|12)([ab])?/);
+          if(combo){
+            grade=combo[1];
+            const letter=combo[2]?combo[2].toUpperCase():'';
+            exam=`AMC_${grade}${letter}`;
+          }
+        }
+      }else if(/usamo|usmo/.test(ql)){
+        exam='USAMO';
+      }else if(/usajmo|usa\s*jmo/.test(ql)){
+        exam='USAJMO';
+      }
+
+      const pm=ql.match(/problem\s*(\d{1,2})/);
+      if(pm) problem=pm[1];
+      if(!problem){
+        const nums=ql.match(/\b\d{1,2}\b/g)||[];
+        for(const n of nums){
+          if(n!==year&&n!==grade){problem=n;break;}
+        }
+      }
+
+      if(exam&&year&&problem){
+        location.href=`https://artofproblemsolving.com/wiki/index.php/${year}_${exam}_Problems/Problem_${Number(problem)}`;
+        return true;
+      }
+      return false;
+    }
+
     searchForm.addEventListener('submit',e=>{
       const q=searchForm.querySelector('input[name="q"]').value.trim();
       if(!q){e.preventDefault();return;}
+      if(problemRedirect(q)){
+        e.preventDefault();
+        return;
+      }
       if(q.toLowerCase().startsWith('aops:')){
         e.preventDefault();
         const query=encodeURIComponent(q.slice(5).trim());
@@ -234,4 +292,5 @@ document.addEventListener('DOMContentLoaded',()=>{
     navigator.serviceWorker.register('sw.js');
   }
 });
+}
 

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@ footer{background:var(--color-muted);text-align:center;padding:1rem;}
     <form id="search-form" role="search" aria-label="Site search" action="search.html">
       <label for="search-input" class="visually-hidden">Search</label>
       <input id="search-input" name="q" type="search" placeholder="Search resources" autocomplete="off">
+      <button type="submit" class="visually-hidden">Search</button>
     </form>
   </section>
   <section class="features">

--- a/search.html
+++ b/search.html
@@ -61,6 +61,7 @@ footer{background:var(--color-muted);text-align:center;padding:1rem;}
   <form id="search-form" role="search" aria-label="Site search" action="search.html">
     <label for="search-input" class="visually-hidden">Search</label>
     <input id="search-input" name="q" type="search" placeholder="Search resources" autocomplete="off">
+    <button type="submit" class="visually-hidden">Search</button>
   </form>
   <p id="search-summary">Showing results for <strong id="search-term"></strong></p>
   <div id="search-results" class="results" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- ensure search forms submit on Enter key
- guard client script against Node execution errors

## Testing
- `npm test`
- `node -e "require('./assets/site.js')"`
- `node - <<'NODE'
function problemUrl(q){
  const ql=q.toLowerCase();
  const tokens=(ql.match(/\w+/g)||[]);
  let year,problem,exam='',grade;

  const ym=ql.match(/(19|20)\d{2}/);
  if(ym) year=ym[0];

  if(/aime/.test(ql)){
    const m=ql.match(/aime\s*(i{1,3}|1|2)?/);
    if(m){
      const v=m[1];
      if(!v) exam='AIME';
      else if(v==='i'||v==='1') exam='AIME_I';
      else if(v==='ii'||v==='2') exam='AIME_II';
      else exam=`AIME_${v.toUpperCase()}`;
    }else exam='AIME';
  }else if(/amc/.test(ql)){
    const m=ql.match(/amc\s*(8|10|12)\s*([ab])?/);
    if(m){
      grade=m[1];
      const letter=m[2]?m[2].toUpperCase():'';
      exam=`AMC_${grade}${letter}`;
    }else{
      const combo=ql.match(/amc(8|10|12)([ab])?/);
      if(combo){
        grade=combo[1];
        const letter=combo[2]?combo[2].toUpperCase():'';
        exam=`AMC_${grade}${letter}`;
      }
    }
  }else if(/usamo|usmo/.test(ql)){
    exam='USAMO';
  }else if(/usajmo|usa\s*jmo/.test(ql)){
    exam='USAJMO';
  }

  const pm=ql.match(/problem\s*(\d{1,2})/);
  if(pm) problem=pm[1];
  if(!problem){
    const nums=ql.match(/\b\d{1,2}\b/g)||[];
    for(const n of nums){
      if(n!==year&&n!==grade){problem=n;break;}
    }
  }

  if(exam&&year&&problem){
    return `https://artofproblemsolving.com/wiki/index.php/${year}_${exam}_Problems/Problem_${Number(problem)}`;
  }
  return null;
}
console.log(problemUrl('2014 aime i problem 8'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689bd9aca0e88327a785186b012e2290