### PR TITLE
Add dynamic AMC/AIME diagnostic

### DIFF
--- a/assets/diagnostic_bank.json
+++ b/assets/diagnostic_bank.json
@@ -1,0 +1,36 @@
+{
+  "AMC": [
+    {"id":"AMC1","section":"Algebra","skill":"algebra.lines","problem":"Solve for x: 3x-5=10","choices":["3","4","5","6"],"answer":2,"difficulty":0.4},
+    {"id":"AMC2","section":"Algebra","skill":"algebra.lines","problem":"For y=2x-1, what is y when x=3?","choices":["3","4","5","6"],"answer":2,"difficulty":0.4},
+    {"id":"AMC3","section":"Algebra","skill":"algebra.lines","problem":"Solve 4x=32","choices":["6","7","8","9"],"answer":2,"difficulty":0.4},
+    {"id":"AMC4","section":"Algebra","skill":"algebra.quadratics","problem":"What is the product of the roots of x^2-3x+2=0?","choices":["1","2","3","5"],"answer":1,"difficulty":0.4},
+    {"id":"AMC5","section":"Algebra","skill":"algebra.quadratics","problem":"How many integer solutions satisfy x^2=9?","choices":["1","2","3","4"],"answer":1,"difficulty":0.4},
+    {"id":"AMC6","section":"Algebra","skill":"algebra.quadratics","problem":"What is the sum of solutions to (x-3)(x+3)=0?","choices":["-6","-3","0","3"],"answer":2,"difficulty":0.4},
+    {"id":"AMC7","section":"Number Theory","skill":"nt.divisibility","problem":"What is the remainder when 14 is divided by 5?","choices":["1","2","3","4"],"answer":3,"difficulty":0.4},
+    {"id":"AMC8","section":"Number Theory","skill":"nt.divisibility","problem":"What is the smallest positive integer divisible by both 3 and 4?","choices":["6","8","12","24"],"answer":2,"difficulty":0.4},
+    {"id":"AMC9","section":"Number Theory","skill":"nt.divisibility","problem":"How many positive divisors does 12 have?","choices":["4","6","8","12"],"answer":1,"difficulty":0.4},
+    {"id":"AMC10","section":"Geometry","skill":"geo.triangles","problem":"A right triangle has legs 3 and 4. What is the hypotenuse?","choices":["5","6","7","8"],"answer":0,"difficulty":0.4},
+    {"id":"AMC11","section":"Geometry","skill":"geo.triangles","problem":"What is the sum of the angles in any triangle?","choices":["90","120","180","360"],"answer":2,"difficulty":0.4},
+    {"id":"AMC12","section":"Geometry","skill":"geo.triangles","problem":"What is the area of a triangle with base 10 and height 6?","choices":["15","30","60","120"],"answer":1,"difficulty":0.4},
+    {"id":"AMC13","section":"Counting","skill":"combo.counting","problem":"How many ways are there to choose 2 objects from 5?","choices":["5","10","20","25"],"answer":1,"difficulty":0.4},
+    {"id":"AMC14","section":"Counting","skill":"combo.counting","problem":"How many permutations of the letters ABC are possible?","choices":["3","4","5","6"],"answer":3,"difficulty":0.4},
+    {"id":"AMC15","section":"Counting","skill":"combo.counting","problem":"A coin is flipped twice. How many outcomes are possible?","choices":["2","3","4","5"],"answer":2,"difficulty":0.4}
+  ],
+  "AIME": [
+    {"id":"AIME1","section":"Algebra","skill":"algebra.lines","problem":"Solve for x: 2x-3=7","choices":["4","5","6","7"],"answer":1,"difficulty":1.0},
+    {"id":"AIME2","section":"Algebra","skill":"algebra.lines","problem":"Find the slope of the line through (0,1) and (2,5)","choices":["1","2","3","4"],"answer":1,"difficulty":1.0},
+    {"id":"AIME3","section":"Algebra","skill":"algebra.lines","problem":"Solve for x: 7x+2=3x+18","choices":["3","4","5","6"],"answer":1,"difficulty":1.0},
+    {"id":"AIME4","section":"Algebra","skill":"algebra.quadratics","problem":"What is the sum of the roots of x^2-7x+12=0?","choices":["5","6","7","8"],"answer":2,"difficulty":1.0},
+    {"id":"AIME5","section":"Algebra","skill":"algebra.quadratics","problem":"Find the positive root of x^2-4x-5=0","choices":["3","4","5","6"],"answer":2,"difficulty":1.0},
+    {"id":"AIME6","section":"Algebra","skill":"algebra.quadratics","problem":"Find the nonzero solution to x^2=2x","choices":["1","2","3","4"],"answer":1,"difficulty":1.0},
+    {"id":"AIME7","section":"Number Theory","skill":"nt.congruences","problem":"Find the smallest x with x≡2 (mod 5) and x≡3 (mod 7)","choices":["12","17","22","27"],"answer":1,"difficulty":1.0},
+    {"id":"AIME8","section":"Number Theory","skill":"nt.congruences","problem":"What is the remainder when 1234 is divided by 11?","choices":["1","2","3","4"],"answer":1,"difficulty":1.0},
+    {"id":"AIME9","section":"Number Theory","skill":"nt.congruences","problem":"Solve for the smallest positive x: 3x≡1 (mod 7)","choices":["2","3","4","5"],"answer":3,"difficulty":1.0},
+    {"id":"AIME10","section":"Geometry","skill":"geo.triangles","problem":"An isosceles triangle has sides 5, 5, and 6. What is its perimeter?","choices":["15","16","17","18"],"answer":1,"difficulty":1.0},
+    {"id":"AIME11","section":"Geometry","skill":"geo.triangles","problem":"What is the area of a right triangle with legs 5 and 12?","choices":["25","30","35","40"],"answer":1,"difficulty":1.0},
+    {"id":"AIME12","section":"Geometry","skill":"geo.triangles","problem":"What is the area of an equilateral triangle with side length 6?","choices":["9","9√3","18","18√3"],"answer":1,"difficulty":1.0},
+    {"id":"AIME13","section":"Counting","skill":"combo.counting","problem":"How many distinct permutations are there of the letters in MISS?","choices":["6","12","24","48"],"answer":1,"difficulty":1.0},
+    {"id":"AIME14","section":"Counting","skill":"combo.counting","problem":"How many ways to choose 2 elements from {1,2,3,4,5,6}?","choices":["10","15","20","30"],"answer":1,"difficulty":1.0},
+    {"id":"AIME15","section":"Counting","skill":"combo.counting","problem":"How many subsets of {1,2,3,4} contain at least one even number?","choices":["8","12","14","16"],"answer":1,"difficulty":1.0}
+  ]
+}

--- a/assets/site.js
+++ b/assets/site.js
@@ -50,51 +50,63 @@ if(typeof document!=='undefined'){
     function problemRedirect(q){
       const ql=q.toLowerCase();
       const tokens=(ql.match(/\w+/g)||[]);
-      let year,problem,exam='',grade;
+      let year,problem,exam,grade,variant;
 
-      const ym=ql.match(/(19|20)\d{2}/);
-      if(ym) year=ym[0];
+      for(const t of tokens){
+        if(/^(19|20)\d{2}$/.test(t)) year=t;
+      }
 
-      if(/aime/.test(ql)){
-        const m=ql.match(/aime\s*(i{1,3}|1|2)?/);
-        if(m){
-          const v=m[1];
-          if(!v) exam='AIME';
-          else if(v==='i'||v==='1') exam='AIME_I';
-          else if(v==='ii'||v==='2') exam='AIME_II';
-          else exam=`AIME_${v.toUpperCase()}`;
-        }else exam='AIME';
-      }else if(/amc/.test(ql)){
-        const m=ql.match(/amc\s*(8|10|12)\s*([ab])?/);
-        if(m){
+      if(tokens.some(t=>t.includes('amc'))){
+        let combo=tokens.find(t=>/^amc(8|10|12)([ab])?$/i.test(t));
+        if(combo){
+          const m=combo.match(/^amc(8|10|12)([ab])?$/i);
           grade=m[1];
-          const letter=m[2]?m[2].toUpperCase():'';
-          exam=`AMC_${grade}${letter}`;
+          variant=m[2];
         }else{
-          const combo=ql.match(/amc(8|10|12)([ab])?/);
+          combo=tokens.find(t=>/^(8|10|12)([ab])?$/i.test(t));
           if(combo){
-            grade=combo[1];
-            const letter=combo[2]?combo[2].toUpperCase():'';
-            exam=`AMC_${grade}${letter}`;
+            const m=combo.match(/^(8|10|12)([ab])?$/i);
+            grade=m[1];
+            variant=m[2];
           }
         }
-      }else if(/usamo|usmo/.test(ql)){
+        if(!grade){
+          const g=tokens.find(t=>/^(8|10|12)$/i.test(t));
+          if(g) grade=g;
+        }
+        if(!variant){
+          const v=tokens.find(t=>/^[ab]$/i.test(t));
+          if(v) variant=v;
+        }
+        if(grade) exam=`AMC_${grade}${variant?variant.toUpperCase():''}`;
+      }else if(tokens.includes('aime')){
+        exam='AIME';
+        const v=tokens.find(t=>/^(i{1,3}|1|2)$/i.test(t));
+        if(v){
+          const vv=v.toLowerCase();
+          if(vv==='1'||vv==='i') exam='AIME_I';
+          else if(vv==='2'||vv==='ii') exam='AIME_II';
+          else exam=`AIME_${vv.toUpperCase()}`;
+          variant=vv;
+        }
+      }else if(tokens.some(t=>t==='usamo'||t==='usmo')){
         exam='USAMO';
-      }else if(/usajmo|usa\s*jmo/.test(ql)){
+      }else if(tokens.some(t=>t==='usajmo'||(t==='usa'&&tokens.includes('jmo')))){
         exam='USAJMO';
       }
 
-      const pm=ql.match(/problem\s*(\d{1,2})/);
-      if(pm) problem=pm[1];
       if(!problem){
-        const nums=ql.match(/\b\d{1,2}\b/g)||[];
-        for(const n of nums){
-          if(n!==year&&n!==grade){problem=n;break;}
+        for(const t of tokens){
+          if(/^\d{1,2}$/.test(t)&&t!==year&&t!==grade&&t!==variant){problem=t;break;}
         }
       }
 
       if(exam&&year&&problem){
         location.href=`https://artofproblemsolving.com/wiki/index.php/${year}_${exam}_Problems/Problem_${Number(problem)}`;
+        return true;
+      }
+      if(exam&&year){
+        location.href=`https://artofproblemsolving.com/wiki/index.php/${year}_${exam}_Problems`;
         return true;
       }
       return false;
@@ -222,9 +234,64 @@ if(typeof document!=='undefined'){
     }
     [prefExam,prefDate,prefMinutes].forEach(el=>el.addEventListener('change',savePrefs));
 
-    diagForm.querySelectorAll('.question').forEach(q=>{
-      q.addEventListener('focusin',()=>{if(!q.dataset.start) q.dataset.start=Date.now();});
-    });
+    let questionBank=null;
+    async function loadQuestions(){
+      questionBank=await fetch('assets/diagnostic_bank.json').then(r=>r.json());
+      renderQuestions();
+    }
+    function renderQuestions(){
+      if(!questionBank) return;
+      const container=document.getElementById('questions-container');
+      let questions=[];
+      const exam=prefExam.value;
+      if(exam==='AIME'){
+        questions=questionBank.AMC.slice(0,10).concat(questionBank.AIME.slice(0,5));
+      }else if(exam==='USAMO'){
+        questions=questionBank.AIME.slice(0,15);
+      }else{
+        questions=questionBank.AMC.slice(0,15);
+      }
+      container.innerHTML='';
+      const sections={};
+      questions.forEach(q=>{(sections[q.section]=sections[q.section]||[]).push(q);});
+      let idx=1;
+      Object.entries(sections).forEach(([section,qs])=>{
+        const sec=document.createElement('section');
+        const h2=document.createElement('h2');
+        h2.textContent=section;
+        sec.appendChild(h2);
+        qs.forEach(q=>{
+          const div=document.createElement('div');
+          div.className='question';
+          div.dataset.skill=q.skill;
+          div.dataset.difficulty=q.difficulty;
+          const fieldset=document.createElement('fieldset');
+          const legend=document.createElement('legend');
+          legend.textContent=`${idx}. ${q.problem}`;
+          fieldset.appendChild(legend);
+          q.choices.forEach((choice,i)=>{
+            const label=document.createElement('label');
+            const input=document.createElement('input');
+            input.type='radio';
+            input.name=`q${idx}`;
+            input.value=choice;
+            if(i===q.answer) input.dataset.correct='1';
+            label.appendChild(input);
+            label.appendChild(document.createTextNode(choice));
+            fieldset.appendChild(label);
+          });
+          div.appendChild(fieldset);
+          sec.appendChild(div);
+          idx++;
+        });
+        container.appendChild(sec);
+      });
+      container.querySelectorAll('.question').forEach(q=>{
+        q.addEventListener('focusin',()=>{if(!q.dataset.start) q.dataset.start=Date.now();});
+      });
+    }
+    prefExam.addEventListener('change',renderQuestions);
+    loadQuestions();
 
     document.getElementById('finish-diagnostic').addEventListener('click',async()=>{
       const responses=[];

--- a/data/aops_map.json
+++ b/data/aops_map.json
@@ -11,5 +11,11 @@
   ],
   "nt.congruences": [
     { "book_id": "Intro_Number_Theory", "chapter": "Congruences", "pages": [201, 228], "problems": ["1-25 odd", "Review 1-10"] }
+  ],
+  "geo.triangles": [
+    { "book_id": "AOPS_Vol1", "chapter": "Geometry: Triangles", "pages": [200, 230], "problems": ["1-20 odd"] }
+  ],
+  "combo.counting": [
+    { "book_id": "AOPS_Vol1", "chapter": "Counting", "pages": [300, 340], "problems": ["1-25 odd"] }
   ]
 }

--- a/data/practice_bank.json
+++ b/data/practice_bank.json
@@ -2,5 +2,7 @@
   { "skill": "algebra.quadratics", "exam": "AIME", "year": 2020, "number": 5, "est_minutes": 10, "difficulty": 1.0 },
   { "skill": "nt.congruences", "exam": "AIME", "year": 2021, "number": 3, "est_minutes": 12, "difficulty": 1.1 },
   { "skill": "algebra.lines", "exam": "AIME", "year": 2019, "number": 2, "est_minutes": 8, "difficulty": 0.9 },
-  { "skill": "nt.divisibility", "exam": "AIME", "year": 2018, "number": 4, "est_minutes": 9, "difficulty": 0.8 }
+  { "skill": "nt.divisibility", "exam": "AIME", "year": 2018, "number": 4, "est_minutes": 9, "difficulty": 0.8 },
+  { "skill": "geo.triangles", "exam": "AIME", "year": 2017, "number": 6, "est_minutes": 12, "difficulty": 1.0 },
+  { "skill": "combo.counting", "exam": "AIME", "year": 2016, "number": 7, "est_minutes": 10, "difficulty": 1.0 }
 ]

--- a/data/skills_graph.json
+++ b/data/skills_graph.json
@@ -2,5 +2,7 @@
   "algebra.lines": { "prereq": [], "weight": { "AMC10": 0.8, "AMC12": 0.9, "AIME": 0.6, "USAMO": 0.3 } },
   "algebra.quadratics": { "prereq": ["algebra.lines"], "weight": { "AMC10": 0.9, "AMC12": 1.0, "AIME": 1.1, "USAMO": 0.5 } },
   "nt.divisibility": { "prereq": [], "weight": { "AMC10": 0.7, "AMC12": 0.9, "AIME": 1.0, "USAMO": 0.6 } },
-  "nt.congruences": { "prereq": ["nt.divisibility"], "weight": { "AMC10": 0.6, "AMC12": 0.9, "AIME": 1.2, "USAMO": 0.8 } }
+  "nt.congruences": { "prereq": ["nt.divisibility"], "weight": { "AMC10": 0.6, "AMC12": 0.9, "AIME": 1.2, "USAMO": 0.8 } },
+  "geo.triangles": { "prereq": [], "weight": { "AMC10": 0.7, "AMC12": 0.8, "AIME": 1.0, "USAMO": 0.9 } },
+  "combo.counting": { "prereq": [], "weight": { "AMC10": 0.8, "AMC12": 0.8, "AIME": 1.1, "USAMO": 0.9 } }
 }

--- a/diagnostic.html
+++ b/diagnostic.html
@@ -79,28 +79,7 @@ footer{background:var(--color-muted);text-align:center;padding:1rem;}
     </label>
   </section>
   <form id="diagnostic-form">
-    <section>
-      <h2>Algebra</h2>
-      <div class="question" data-skill="algebra" data-difficulty="easy">
-        <fieldset>
-          <legend>1. Solve for x: 2x = 6</legend>
-          <label><input type="radio" name="q1" value="1">1</label>
-          <label><input type="radio" name="q1" value="2">2</label>
-          <label><input type="radio" name="q1" value="3" data-correct="1">3</label>
-        </fieldset>
-      </div>
-    </section>
-    <section>
-      <h2>Number Theory</h2>
-      <div class="question" data-skill="number_theory" data-difficulty="medium">
-        <fieldset>
-          <legend>2. What is the remainder when 7² is divided by 5?</legend>
-          <label><input type="radio" name="q2" value="4" data-correct="1">4</label>
-          <label><input type="radio" name="q2" value="2">2</label>
-          <label><input type="radio" name="q2" value="3">3</label>
-        </fieldset>
-      </div>
-    </section>
+    <div id="questions-container"></div>
     <button type="button" id="finish-diagnostic">Finish</button>
   </form>
   <pre id="plan-md"></pre>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node build.mjs",
     "test": "vitest run",
     "plan": "node dist/cli.js --diagnostic data/diagnostic_results.json --skills data/skills_graph.json --aops data/aops_map.json --practice data/practice_bank.json --policy data/policy.json --out out"
   },

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -38,7 +38,7 @@ describe('planning pipeline', () => {
     const first14 = plan.filter(d => parseISO(d.date) < addDays(parseISO(startDate), 14));
     const skillsSet = new Set<string>();
     first14.forEach(day => day.blocks.forEach(b => skillsSet.add(b.skill)));
-    const expected = ['algebra.lines', 'algebra.quadratics', 'nt.divisibility', 'nt.congruences'];
+    const expected = ['algebra.lines', 'algebra.quadratics', 'nt.divisibility', 'nt.congruences', 'geo.triangles', 'combo.counting'];
     expect([...skillsSet].every(s => expected.includes(s))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- add 15-question diagnostic built from AMC and AIME problem banks that adapts to target exam
- expand skills graph and resources with geometry and counting coverage
- adjust pipeline tests for new skills
- improve search query parsing and exam-year redirects
- run build script to copy static assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bdfca0ce88327b5c8724fc5ed1011