### PR TITLE
Fix diagnostic flow and cache study plan

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -320,14 +320,14 @@ if(typeof document!=='undefined'){
             fetch('assets/policy.json').then(r=>r.json())
           ]);
           const plan=await window.OlympiadEngine.planFromDiagnostic(results,{skills,bank,map,policy});
-
+          localStorage.setItem('studyPlanJson',JSON.stringify(plan));
           location.href='study-plan.html';
         }catch(err){
           console.error(err);
           alert('Could not generate plan.');
         }
       }else{
-
+        alert('Diagnostic engine not available.');
       }
     });
   }

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
-const CACHE='olympiad-v2';
+const CACHE='olympiad-v3';
 const ASSETS=[
   './',
   './index.html','./search.html','./diagnostic.html','./planning.html','./books.html','./tutor.html','./404.html',
   './assets/site.css','./assets/site.js','./assets/books.json','./assets/search-index.json',
-  './assets/skills_graph.json','./assets/practice_bank.json','./assets/aops_map.json','./assets/policy.json',
+  './assets/skills_graph.json','./assets/practice_bank.json','./assets/aops_map.json','./assets/policy.json','./assets/diagnostic_bank.json',
   './manifest.webmanifest','./favicon.svg'
 ];
 


### PR DESCRIPTION
## Summary
- Persist study plan to localStorage and redirect to study page
- Cache diagnostic question bank and bump service worker version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf329970c8327ba7e82e149510b7d