### PR TITLE
Add tutor form and allow contest-only searches

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       <h2>Find any contest problem instantly</h2>
       <p class="subtitle">Your AI-powered companion for Olympiad success.</p>
       <form class="lookup-form" onsubmit="handleSearch(event)">
-        <input type="text" id="lookup-query" placeholder="e.g. AMC 12B 2023 Problem 14" required>
+        <input type="text" id="lookup-query" placeholder="e.g. AIME I 2022 or AMC 12B 2023 Problem 14" required>
         <button type="submit">Search</button>
       </form>
     </div>
@@ -114,8 +114,8 @@
       }
 
       let url = null;
-      if (!year || !problem || !contest) {
-        alert('Please include a year, contest, and problem number');
+      if (!year || !contest) {
+        alert('Please include a year and contest');
         return;
       }
 
@@ -129,19 +129,28 @@
             alert('Please specify A or B');
             return;
           }
-          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_${level}${variant}_Problems/Problem_${problem}`;
+          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_${level}${variant}_Problems`;
         } else {
-          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_${level}_Problems/Problem_${problem}`;
+          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AMC_${level}_Problems`;
+        }
+        if (problem) {
+          url += `/Problem_${problem}`;
         }
       } else if (contest === 'AIME') {
         if (parseInt(year) >= 2000) {
           variant = variant || 'I';
-          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AIME_${variant}_Problems/Problem_${problem}`;
+          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AIME_${variant}_Problems`;
         } else {
-          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AIME_Problems/Problem_${problem}`;
+          url = `https://artofproblemsolving.com/wiki/index.php/${year}_AIME_Problems`;
+        }
+        if (problem) {
+          url += `/Problem_${problem}`;
         }
       } else if (contest === 'USAMO') {
-        url = `https://artofproblemsolving.com/wiki/index.php/${year}_USAMO_Problems/Problem_${problem}`;
+        url = `https://artofproblemsolving.com/wiki/index.php/${year}_USAMO_Problems`;
+        if (problem) {
+          url += `/Problem_${problem}`;
+        }
       }
 
       if (url) {

--- a/styles.css
+++ b/styles.css
@@ -127,7 +127,8 @@ main.container {
   margin: 1rem auto;
   text-align: left;
 }
-.diagnostic-form {
+.diagnostic-form,
+.tutor-form {
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
@@ -142,13 +143,18 @@ main.container {
   margin-bottom: 0.25rem;
 }
 .diagnostic-form select,
-.diagnostic-form button {
+.diagnostic-form button,
+.tutor-form input,
+.tutor-form select,
+.tutor-form textarea,
+.tutor-form button {
   padding: 0.75rem 1rem;
   border: 1px solid #ccc;
   border-radius: 6px;
   font-size: 1rem;
 }
-.diagnostic-form button {
+.diagnostic-form button,
+.tutor-form button {
   background: var(--accent);
   color: #fff;
   border: none;
@@ -156,7 +162,8 @@ main.container {
   transition: background 0.2s;
   align-self: flex-start;
 }
-.diagnostic-form button:hover {
+.diagnostic-form button:hover,
+.tutor-form button:hover {
   background: #4f46e5;
 }
 .book-list {

--- a/tutor.html
+++ b/tutor.html
@@ -20,7 +20,33 @@
   </header>
   <main class="container">
     <h2>👩‍🏫 Need a Tutor?</h2>
-    <p>Connect with experienced mentors for personalized guidance. This page is under construction.</p>
+    <p>Connect with experienced mentors for personalized guidance. Fill out the form below and we'll be in touch.</p>
+    <form class="tutor-form">
+      <div class="form-group">
+        <label for="tutor-name">Name</label>
+        <input type="text" id="tutor-name" required>
+      </div>
+      <div class="form-group">
+        <label for="tutor-email">Email</label>
+        <input type="email" id="tutor-email" required>
+      </div>
+      <div class="form-group">
+        <label for="tutor-level">Contest Level</label>
+        <select id="tutor-level" required>
+          <option value="">Select level</option>
+          <option>AMC 8</option>
+          <option>AMC 10</option>
+          <option>AMC 12</option>
+          <option>AIME</option>
+          <option>USAMO</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="tutor-message">Message</label>
+        <textarea id="tutor-message" rows="4"></textarea>
+      </div>
+      <button type="submit">Submit</button>
+    </form>
   </main>
   <footer>
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.


### PR DESCRIPTION
## Summary
- Add a contact form on the tutor page so visitors can request mentorship.
- Allow the homepage search to open whole contest pages when no problem number is provided.
- Style the new tutor form alongside existing diagnostic form styles.

## Testing
- `python -m py_compile study_plan.py`


------
https://chatgpt.com/codex/tasks/task_e_689c0310b99c8327b4e8ab81562c62b1