### PR TITLE
Remove AMC10 diagnostic test

### DIFF
--- a/diagnostic.html
+++ b/diagnostic.html
@@ -27,5 +27,15 @@
     © 2025 OlympiadPrep. Empowering tomorrow’s problem solvers.
   </footer>
   <script src="plan.js"></script>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const goal = params.get('goal');
+    const quiz = document.getElementById('quiz');
+    if (goal === 'amc10') {
+      quiz.innerHTML = '<p>The AMC 10 diagnostic test has been removed.</p>';
+    } else {
+      quiz.innerHTML = '<p>No diagnostic test is currently available for this goal.</p>';
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Keep AMC 10 option on planning page while ensuring the diagnostic test no longer appears when selected
- Display a notice on the diagnostic page explaining the AMC 10 test has been removed

## Testing
- `python -m py_compile study_plan.py`
- `python study_plan.py meta.json > /tmp/plan.json`


------
https://chatgpt.com/codex/tasks/task_e_689fed0346ec83279f7511bd70189eed